### PR TITLE
Remove Vaadin tables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,18 @@
 {
-    "name": "pokemongogo",
-    "dependencies": {
-        "bootstrap" : "^3.3.6",
-        "jquery": "2.2.4",
-        "webcomponentsjs": "^0.7.22",
-        "web-component-tester": "^4.3.1",
-        "polymer": "Polymer/polymer#^1.5.0",
-		"app-route": "PolymerElements/app-route#^0.9.2",
-		"neon-animation": "PolymerElements/neon-animation#^1.2.4",
-		"iron-pages": "PolymerElements/iron-pages#^1.0.8",
-        "iron-ajax": "PolymerElements/iron-ajax#^1.4.3",
-        "vaadin-grid" : "^1.1.1"
-    },
-    "devDependencies": {
-        "iron-component-page": "PolymerElements/iron-component-page#^1.1.7"
-    }
+  "name": "pokemongogo",
+  "dependencies": {
+    "bootstrap": "^3.3.6",
+    "jquery": "2.2.4",
+    "webcomponentsjs": "^0.7.22",
+    "web-component-tester": "^4.3.1",
+    "polymer": "Polymer/polymer#^1.5.0",
+    "app-route": "PolymerElements/app-route#^0.9.2",
+    "neon-animation": "PolymerElements/neon-animation#^1.2.4",
+    "iron-pages": "PolymerElements/iron-pages#^1.0.8",
+    "iron-ajax": "PolymerElements/iron-ajax#^1.4.3",
+    "paper-datatable": "^0.9.8"
+  },
+  "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1.7"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "paper-datatable": "^0.9.8"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.1.7"
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1.7",
+    "paper-elements": "PolymerElements/paper-elements#^1.0.7"
   }
 }

--- a/src/main/java/com/thejavatar/pokemongogo/Evolution.java
+++ b/src/main/java/com/thejavatar/pokemongogo/Evolution.java
@@ -2,6 +2,9 @@ package com.thejavatar.pokemongogo;
 
 import com.pokegoapi.api.pokemon.Pokemon;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * Created by theJavatar.com on 31/07/16.
@@ -9,19 +12,27 @@ import com.pokegoapi.api.pokemon.Pokemon;
 public class Evolution {
 
     private final Pokemon pokemon;
+    private final List<PokemonDecorator> pokemonsToEvolve;
     private final int pokemonAmount;
 
     public Evolution(Pokemon pokemon, int pokemonAmount) {
         this.pokemon = pokemon;
         this.pokemonAmount = pokemonAmount;
+        this.pokemonsToEvolve = new ArrayList<>();
     }
 
+    @SuppressWarnings("unused")
     public Integer getNumberOfCandies() {
         return pokemon.getCandy();
     }
 
-    public Integer getNumberOfEvolutions() {
+    public Integer getNumberOfPossibleEvolutions() {
         return Math.min(calculateEvolutionsBasedOnCandies(), pokemonAmount);
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getNumberOfEvolutions() {
+        return pokemonsToEvolve.size();
     }
 
     private Integer calculateEvolutionsBasedOnCandies() {
@@ -34,7 +45,20 @@ public class Evolution {
         }
     }
 
+    public void addPokemon(Pokemon pokemon) {
+        this.pokemonsToEvolve.add(new PokemonDecorator(pokemon));
+    }
+
+    public Integer getNumberOfRemainingEvolutions() {
+        return calculateEvolutionsBasedOnCandies() - this.pokemonsToEvolve.size();
+    }
+
     public String getPokemon() {
         return pokemon.getPokemonId().name();
+    }
+
+    @SuppressWarnings("unused")
+    public List<PokemonDecorator> getPokemonsToEvolve() {
+        return pokemonsToEvolve;
     }
 }

--- a/src/main/java/com/thejavatar/pokemongogo/apifacade/PokemonApiFacade.java
+++ b/src/main/java/com/thejavatar/pokemongogo/apifacade/PokemonApiFacade.java
@@ -54,7 +54,7 @@ public class PokemonApiFacade {
             Map<PokemonFamilyIdOuterClass.PokemonFamilyId, Evolution> evolutions = new HashMap<>();
             PokeBank pokebank = api.getApi(auth, username).getInventories().getPokebank();
             List<Pokemon> pokemons = pokebank.getPokemons();
-            pokemons.sort(OrderBy.BY_IV.getComparator());
+            pokemons.sort(PokemonOrderBy.BY_IV.getComparator());
             pokemons.forEach(pokemon -> {
                 Evolution evolution;
                 PokemonFamilyIdOuterClass.PokemonFamilyId family = pokemon.getPokemonFamily();
@@ -73,6 +73,7 @@ public class PokemonApiFacade {
 
             return evolutions.values().stream()
                     .filter(evolution -> evolution.getNumberOfEvolutions() > 0)
+                    .sorted(EvolutionOrderBy.BY_EVOLUTIONS.getComparator())
                     .collect(Collectors.toList());
         } catch (Exception e) {
             throw new PokemonApiFacadeException(e.getMessage(), e);
@@ -169,12 +170,12 @@ public class PokemonApiFacade {
         }
     }
 
-    private enum OrderBy {
+    private enum PokemonOrderBy {
         BY_IV((pokemon1, pokemon2) -> getPerfectIv(pokemon2).compareTo(getPerfectIv(pokemon1)));
 
         private final Comparator<Pokemon> comparator;
 
-        OrderBy(Comparator<Pokemon> comparator) {
+        PokemonOrderBy(Comparator<Pokemon> comparator) {
             this.comparator = comparator;
         }
 
@@ -185,6 +186,20 @@ public class PokemonApiFacade {
         private static Double getPerfectIv(Pokemon pokemon) {
             double perfectIv = (pokemon.getIndividualAttack() + pokemon.getIndividualDefense() + pokemon.getIndividualStamina()) * 100 / 45;
             return perfectIv;
+        }
+    }
+
+    private enum EvolutionOrderBy {
+        BY_EVOLUTIONS((pokemon1, pokemon2) -> pokemon2.getNumberOfEvolutions().compareTo(pokemon1.getNumberOfEvolutions()));
+
+        private final Comparator<Evolution> comparator;
+
+        EvolutionOrderBy(Comparator<Evolution> comparator) {
+            this.comparator = comparator;
+        }
+
+        public Comparator<Evolution> getComparator() {
+            return comparator;
         }
     }
 }

--- a/src/main/java/com/thejavatar/pokemongogo/apifacade/PokemonApiFacade.java
+++ b/src/main/java/com/thejavatar/pokemongogo/apifacade/PokemonApiFacade.java
@@ -54,22 +54,26 @@ public class PokemonApiFacade {
             Map<PokemonFamilyIdOuterClass.PokemonFamilyId, Evolution> evolutions = new HashMap<>();
             PokeBank pokebank = api.getApi(auth, username).getInventories().getPokebank();
             List<Pokemon> pokemons = pokebank.getPokemons();
+            pokemons.sort(OrderBy.BY_IV.getComparator());
             pokemons.forEach(pokemon -> {
-                int totalNumberOfPokemonOfThisType = pokebank.getPokemonByPokemonId(pokemon.getPokemonId()).size();
-                Evolution evolution = createEvolution(pokemon, totalNumberOfPokemonOfThisType);
+                Evolution evolution;
                 PokemonFamilyIdOuterClass.PokemonFamilyId family = pokemon.getPokemonFamily();
-                if (evolution.getNumberOfEvolutions() > 0) {
-                    if (evolutions.containsKey(family)) {
-                        Integer prev = evolutions.get(family).getNumberOfEvolutions();
-                        if (evolution.getNumberOfEvolutions() > prev) {
-                            evolutions.put(family, evolution);
-                        }
-                    } else {
+                if(evolutions.containsKey(family)) {
+                    evolution = evolutions.get(family);
+                } else {
+                    evolution = createEvolution(pokemon, pokebank.getPokemonByPokemonId(pokemon.getPokemonId()).size());
+                    if(evolution.getNumberOfPossibleEvolutions() > 0) {
                         evolutions.put(family, evolution);
                     }
                 }
+                if (evolution.getNumberOfRemainingEvolutions() > 0 && canEvolve(pokemon)) {
+                    evolution.addPokemon(pokemon);
+                }
             });
-            return evolutions.values();
+
+            return evolutions.values().stream()
+                    .filter(evolution -> evolution.getNumberOfEvolutions() > 0)
+                    .collect(Collectors.toList());
         } catch (Exception e) {
             throw new PokemonApiFacadeException(e.getMessage(), e);
         }
@@ -77,5 +81,110 @@ public class PokemonApiFacade {
 
     private Evolution createEvolution(Pokemon pokemon, int pokemonAmount) {
         return new Evolution(pokemon, pokemonAmount);
+    }
+
+    private Boolean canEvolve(Pokemon pokemon) {
+        switch (pokemon.getPokemonId().getNumber()) {
+            case 3:
+            case 6:
+            case 9:
+            case 12:
+            case 15:
+            case 18:
+            case 20:
+            case 22:
+            case 24:
+            case 26:
+            case 28:
+            case 31:
+            case 34:
+            case 36:
+            case 38:
+            case 40:
+            case 42:
+            case 45:
+            case 47:
+            case 49:
+            case 51:
+            case 53:
+            case 55:
+            case 57:
+            case 59:
+            case 62:
+            case 65:
+            case 68:
+            case 71:
+            case 73:
+            case 76:
+            case 78:
+            case 80:
+            case 82:
+            case 83:
+            case 85:
+            case 87:
+            case 89:
+            case 91:
+            case 94:
+            case 95:
+            case 97:
+            case 99:
+            case 101:
+            case 103:
+            case 105:
+            case 107:
+            case 108:
+            case 110:
+            case 112:
+            case 113:
+            case 114:
+            case 115:
+            case 117:
+            case 119:
+            case 121:
+            case 122:
+            case 123:
+            case 124:
+            case 125:
+            case 126:
+            case 127:
+            case 128:
+            case 130:
+            case 131:
+            case 132:
+            case 134:
+            case 135:
+            case 136:
+            case 137:
+            case 139:
+            case 141:
+            case 142:
+            case 143:
+            case 144:
+            case 145:
+            case 146:
+            case 149:
+            case 150:
+            case 151: return false;
+            default: return true;
+        }
+    }
+
+    private enum OrderBy {
+        BY_IV((pokemon1, pokemon2) -> getPerfectIv(pokemon2).compareTo(getPerfectIv(pokemon1)));
+
+        private final Comparator<Pokemon> comparator;
+
+        OrderBy(Comparator<Pokemon> comparator) {
+            this.comparator = comparator;
+        }
+
+        public Comparator<Pokemon> getComparator() {
+            return comparator;
+        }
+
+        private static Double getPerfectIv(Pokemon pokemon) {
+            double perfectIv = (pokemon.getIndividualAttack() + pokemon.getIndividualDefense() + pokemon.getIndividualStamina()) * 100 / 45;
+            return perfectIv;
+        }
     }
 }

--- a/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
+++ b/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
@@ -17,35 +17,23 @@
 
         <h1>Total</h1>
 
-        <vaadin-grid id="total" selection-mode="disabled">
-            <table>
-                <colgroup>
-                    <col>
-                    <col>
-                    <col>
-                    <col>
-                    <col>
-                </colgroup>
-                <thead>
-                <tr>
-                    <th></th>
-                    <th>Number of evolutions</th>
-                    <th>Number of candies</th>
-                    <th>Total time* (min)</th>
-                    <th>Total EXP**</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td>Total</td>
-                    <td id="totalEvo">0</td>
-                    <td id="totalCandies">0</td>
-                    <td id="totalTime">0</td>
-                    <td id="totalExp">0</td>
-                </tr>
-                </tbody>
-            </table>
-        </vaadin-grid>
+        <paper-datatable id="table">
+            <paper-datatable-column property="total">
+                <template>[[item.total]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions">
+                <template>[[item.numberOfEvolutions]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Number of candies" property="numberOfCandies">
+                <template>[[item.numberOfCandies]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Total time* (min)" property="totalTime">
+                <template>[[item.totalTime]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Total EXP**" property="totalExp">
+                <template>[[item.totalExp]]</template>
+            </paper-datatable-column>
+        </paper-datatable>
 
         <div class="note">
             * 30 second for each evolution<br/>
@@ -54,76 +42,80 @@
 
         <h1>Details</h1>
 
-        <vaadin-grid id="grid" selection-mode="multi">
-            <table>
-                <colgroup>
-                    <col sortable name="pokemon"/>
-                    <col sortable sort-direction="desc" name="numberOfEvolutions"/>
-                    <col sortable name="numberOfCandies"/>
-                </colgroup>
-                <thead>
-                <tr>
-                    <th>Pokemon</th>
-                    <th>Number of evolutions</th>
-                    <th>Number of candies</th>
-                    <!--<th>Time</th>-->
-                </tr>
-                </thead>
-                <!--<tfoot>
-                <tr>
-                    <th>Total</th>
-                    <th>0</th>
-                    <th>{{total}}</th>
-                </tr>
-                </tfoot>-->
-            </table>
-        </vaadin-grid>
-
+        <paper-datatable id="grid" data="[[data]]" selected-items="{{selectedItems}}"
+                         selectable multi-selection>
+            <paper-datatable-column header="Pokemon" property="pokemon" sortable>
+                <template>[[item.pokemon]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions">
+                <template>[[item.numberOfEvolutions]]</template>
+            </paper-datatable-column>
+            <paper-datatable-column header="Number of candies" property="numberOfCandies">
+                <template>[[item.numberOfCandies]]</template>
+            </paper-datatable-column>
+        </paper-datatable>
     </template>
-    <script>
 
+    <script>
         Polymer({
             is: "evolutions-table",
             properties: {
                 data: {
-                    type: Array,
-                    observer: '_updateTable'
+                    type: Array
+                },
+                selectedItems: {
+                    type: Array
                 }
             },
             ready: function () {
                 var self = this;
                 var grid = self.$.grid;
-                grid.addEventListener('sort-order-changed', function () {
-                    console.log('sort-order-changed');
-                    if (self.data !== undefined) {
-                        var idx = grid.sortOrder[0].column;
-                        var idxName = grid.columns[idx].name;
-                        var lesser = grid.sortOrder[0].direction == 'asc' ? -1 : 1;
-                        self.data.sort(function (a, b) {
-                            return (a[idxName] < b[idxName]) ? lesser : -lesser;
-                        });
-                    }
-                });
-                grid.addEventListener('selected-items-changed', function () {
-                    console.log('selected-items-changed');
-                    self.$.totalCandies.textContent = self._getTotal("numberOfCandies");
+                var table = self.$.table;
+
+                var evolutions = {
+                    numberOfEvolutions: "0",
+                    numberOfCandies: "0",
+                    totalTime: "0",
+                    totalExp: "0",
+                    total: "Total"
+                };
+
+                var evolutionData = [];
+                evolutionData.push(evolutions);
+                table.data = evolutionData;
+
+                grid.addEventListener('selection-changed', function (ev) {
+                    var evolutions = {
+                        numberOfEvolutions: "0",
+                        numberOfCandies: "0",
+                        totalTime: "0",
+                        totalExp: "0",
+                        total: "Total"
+                    };
+
+                    evolutions.numberOfCandies = self._getTotal("numberOfCandies");
                     var numberOfEvolutions = self._getTotal("numberOfEvolutions");
-                    self.$.totalEvo.textContent = numberOfEvolutions;
+                    evolutions.numberOfEvolutions = numberOfEvolutions;
                     if (numberOfEvolutions > 0) {
-                        self.$.totalTime.textContent = self._getTotal("numberOfEvolutions") / 2;
+                        evolutions.totalTime = self._getTotal("numberOfEvolutions") / 2;
                     } else {
-                        self.$.totalTime.textContent = 0;
+                        evolutions.totalTime = 0;
                     }
                     var formatter = new Intl.NumberFormat('en-US', {
                         style: 'decimal',
                         minimumFractionDigits: 0,
                     });
-                    self.$.totalExp.textContent = formatter.format(numberOfEvolutions * 1000);
+                    evolutions.totalExp = formatter.format(numberOfEvolutions * 1000);
+
+                    var evolutionData = [];
+                    evolutionData.push(evolutions);
+                    table.data = evolutionData;
+                    table.reload();
                 });
             },
             _getTotal: function (field) {
                 var self = this;
-                var selected = self._getSelectedItems();
+                var selected = self.selectedItems;
                 if (selected.length > 0) {
                     return selected.map(function (evolution) {
                         return evolution[field];
@@ -133,26 +125,7 @@
                 } else {
                     return 0;
                 }
-            },
-            _getSelectedItems: function () {
-                var self = this;
-                var selectedIndices = self.$.grid.selection.selected();
-                if (self.data != undefined) {
-                    return self.data.filter(function (value, index) {
-                        return selectedIndices.indexOf(index) != -1;
-                    });
-                } else {
-                    return [];
-                }
-            },
-            _updateTable: function (newData, oldData) {
-                console.log('_updateTable');
-                this.$.grid.items = newData;
-                this.$.grid.size = newData.length;
-                this.$.grid.refreshItems();
             }
         });
-
-
     </script>
 </dom-module>

--- a/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
+++ b/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
@@ -44,13 +44,13 @@
 
         <paper-datatable id="grid" data="[[data]]" selected-items="{{selectedItems}}"
                          selectable multi-selection>
-            <paper-datatable-column header="Pokemon" property="pokemon" sortable>
+            <paper-datatable-column header="Pokemon" property="pokemon" type="String" sortable sort-direction="desc">
                 <template>[[item.pokemon]]</template>
             </paper-datatable-column>
-            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions">
+            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions" type="Number" sortable sort-direction="desc">
                 <template>[[item.numberOfEvolutions]]</template>
             </paper-datatable-column>
-            <paper-datatable-column header="Number of candies" property="numberOfCandies">
+            <paper-datatable-column header="Number of candies" property="numberOfCandies" type="Number" sortable sort-direction="desc">
                 <template>[[item.numberOfCandies]]</template>
             </paper-datatable-column>
         </paper-datatable>

--- a/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
+++ b/src/main/resources/static/gogo_components/evolutions-table/evolutions-table.html
@@ -10,50 +10,60 @@
         <style>
             .note {
                 color: gray;
+                margin-bottom: 20px;;
+            }
+            #tableCard {
+                margin-bottom: 10px;
             }
         </style>
 
         <iron-ajax url="/getEvolutions/" last-response="{{data}}" auto></iron-ajax>
 
-        <h1>Total</h1>
-
-        <paper-datatable id="table">
-            <paper-datatable-column property="total">
-                <template>[[item.total]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions">
-                <template>[[item.numberOfEvolutions]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Number of candies" property="numberOfCandies">
-                <template>[[item.numberOfCandies]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Total time* (min)" property="totalTime">
-                <template>[[item.totalTime]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Total EXP**" property="totalExp">
-                <template>[[item.totalExp]]</template>
-            </paper-datatable-column>
-        </paper-datatable>
+        <paper-datatable-card id="tableCard" header="Total">
+            <div toolbar-main>
+            </div>
+            <paper-datatable id="table">
+                <paper-datatable-column property="total">
+                    <template>[[item.total]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions">
+                    <template>[[item.numberOfEvolutions]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Number of candies" property="numberOfCandies">
+                    <template>[[item.numberOfCandies]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Total time* (min)" property="totalTime">
+                    <template>[[item.totalTime]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Total EXP**" property="totalExp">
+                    <template>[[item.totalExp]]</template>
+                </paper-datatable-column>
+            </paper-datatable>
+        </paper-datatable-card>
 
         <div class="note">
             * 30 second for each evolution<br/>
             ** with lucky egg
         </div>
 
-        <h1>Details</h1>
-
-        <paper-datatable id="grid" data="[[data]]" selected-items="{{selectedItems}}"
-                         selectable multi-selection>
-            <paper-datatable-column header="Pokemon" property="pokemon" type="String" sortable sort-direction="desc">
-                <template>[[item.pokemon]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions" type="Number" sortable sort-direction="desc">
-                <template>[[item.numberOfEvolutions]]</template>
-            </paper-datatable-column>
-            <paper-datatable-column header="Number of candies" property="numberOfCandies" type="Number" sortable sort-direction="desc">
-                <template>[[item.numberOfCandies]]</template>
-            </paper-datatable-column>
-        </paper-datatable>
+        <paper-datatable-card id="gridCard" header="Details" page-size="10"
+                              id-property="pokemon" selected-ids="{{selectedIds}}">
+            <paper-datatable id="grid" selected-items="{{selectedItems}}" data="[[data]]"
+                             selectable multi-selection>
+                <div no-results>
+                    Loading...
+                </div>
+                <paper-datatable-column header="Pokemon" property="pokemon" type="String" sortable sort-direction="desc">
+                    <template>[[value]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Number of evolutions" property="numberOfEvolutions" type="Number" sortable sort-direction="desc">
+                    <template>[[value]]</template>
+                </paper-datatable-column>
+                <paper-datatable-column header="Number of candies" property="numberOfCandies" type="Number" sortable sort-direction="desc">
+                    <template>[[value]]</template>
+                </paper-datatable-column>
+            </paper-datatable>
+        </paper-datatable-card>
     </template>
 
     <script>
@@ -64,6 +74,10 @@
                     type: Array
                 },
                 selectedItems: {
+                    type: Array
+                }
+                ,
+                selectedIds: {
                     type: Array
                 }
             },

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -9,8 +9,12 @@
         body {
             margin: 0 30px;
             padding-top: 70px;
+            background-color: lightgrey;
         }
         .progress {
+            display: none;
+        }
+        #bottomBlock {
             display: none;
         }
     </style>
@@ -76,6 +80,8 @@ about the ampersands and crashes.
 <link th:href="@{bower_components/iron-pages/iron-pages.html}" rel="import"/>
 <link th:href="@{bower_components/iron-ajax/iron-ajax.html}" rel="import"/>
 <link th:href="@{bower_components/paper-datatable/paper-datatable.html}" rel="import"/>
+<link th:href="@{bower_components/paper-datatable/paper-datatable-card.html}" rel="import"/>
+<link th:href="@{bower_components/paper-datatable/paper-datatable-column.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-list/pokemon-list.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-view/pokemon-view.html}" rel="import"/>
 <link th:href="@{gogo_components/evolutions-table/evolutions-table.html}" rel="import"/>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -76,7 +76,6 @@ about the ampersands and crashes.
 <link th:href="@{bower_components/iron-pages/iron-pages.html}" rel="import"/>
 <link th:href="@{bower_components/iron-ajax/iron-ajax.html}" rel="import"/>
 <link th:href="@{bower_components/paper-datatable/paper-datatable.html}" rel="import"/>
-<link th:href="@{bower_components/vaadin-grid/vaadin-grid.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-list/pokemon-list.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-view/pokemon-view.html}" rel="import"/>
 <link th:href="@{gogo_components/evolutions-table/evolutions-table.html}" rel="import"/>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -10,6 +10,9 @@
             margin: 0 30px;
             padding-top: 70px;
         }
+        .progress {
+            display: none;
+        }
     </style>
 
     <script type="text/javascript" th:inline="javascript">
@@ -72,11 +75,11 @@ about the ampersands and crashes.
 <link th:href="@{bower_components/app-route/app-location.html}" rel="import"/>
 <link th:href="@{bower_components/iron-pages/iron-pages.html}" rel="import"/>
 <link th:href="@{bower_components/iron-ajax/iron-ajax.html}" rel="import"/>
+<link th:href="@{bower_components/paper-datatable/paper-datatable.html}" rel="import"/>
 <link th:href="@{bower_components/vaadin-grid/vaadin-grid.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-list/pokemon-list.html}" rel="import"/>
 <link th:href="@{gogo_components/pokemon-view/pokemon-view.html}" rel="import"/>
 <link th:href="@{gogo_components/evolutions-table/evolutions-table.html}" rel="import"/>
-
 
 <div th:remove="tag" layout:fragment="javascript"></div>
 

--- a/src/main/resources/templates/pages/index.html
+++ b/src/main/resources/templates/pages/index.html
@@ -24,8 +24,8 @@
 <div layout:fragment="content">
 
     <ul class="nav nav-tabs navbar-fixed-top">
-        <li id="list" role="presentation" class="dropdown active">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#/list" role="button" aria-haspopup="true"
+        <li id="list" role="presentation" class="dropdown">
+            <a class="dropdown-toggle" data-toggle="dropdown" href="" role="button" aria-haspopup="true"
                aria-expanded="false">
                 Pokemons <span class="caret"></span>
             </a>


### PR DESCRIPTION
Replaces the vaadin-grid components with paper-datatable.
Fixed sort when opening the page (had to be done server side).
Corrected issue that displayed pokemons that cannot be evolved as possibilities for evolution.
Added server side support to display which pokemons should be evolved.
